### PR TITLE
Revert "chore(deps): bump bootstrap from 5.3.2 to 5.3.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dominicbarnes.github.com",
       "version": "0.0.0",
       "dependencies": {
-        "bootstrap": "^5.3.3",
+        "bootstrap": "^5.0.1",
         "bootstrap-icons": "^1.11.3"
       }
     },
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "author": "Dominic Barnes <dominic@dbarnes.info>",
   "dependencies": {
-    "bootstrap": "^5.3.3",
+    "bootstrap": "^5.0.1",
     "bootstrap-icons": "^1.11.3"
   }
 }


### PR DESCRIPTION
Reverts dominicbarnes/dominicbarnes.github.com#3

This appears to have broken the site, so I will need to test this out locally before upgrading again.